### PR TITLE
Update to allow either zend-mvc v2 or v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
 		}
 	],
 	"require": {
-		"zendframework/zend-http": "2.*",
-		"zendframework/zend-mvc": "2.* || 3.*"
+		"zendframework/zend-http": "^2.6",
+		"zendframework/zend-mvc": "^2.7.9 || ^3.1"
 	},
 	"require-dev": {
 		"mikey179/vfsStream": "*",

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,20 +1,29 @@
 <?php
 
+use RdnCsv\Controller\Plugin;
+use Zend\ServiceManager\Factory\InvokableFactory;
+
 return array(
 	'controller_plugins' => array(
 		'aliases' => array(
-			'CsvExport' => 'RdnCsv:CsvExport',
-			'CsvImport' => 'RdnCsv:CsvImport',
+			'CsvExport'        => Plugin\CsvExport::class,
+			'CsvImport'        => Plugin\CsvImport::class,
+			'RdnCsv:CsvExport' => Plugin\CsvExport::class,
+			'RdnCsv:CsvImport' => Plugin\CsvImport::class,
 		),
 
-		'invokables' => array(
-			'RdnCsv:CsvExport' => 'RdnCsv\Controller\Plugin\CsvExport',
-			'RdnCsv:CsvImport' => 'RdnCsv\Controller\Plugin\CsvImport',
+		'factories' => array(
+			Plugin\CsvExport::class => InvokableFactory::class,
+			Plugin\CsvImport::class => InvokableFactory::class,
 		),
 
 		'shared' => array(
-			'RdnCsv:CsvExport' => false,
-			'RdnCsv:CsvImport' => false,
+			'CsvExport'             => false,
+			'CsvImport'             => false,
+            Plugin\CsvExport::class => false,
+            Plugin\CsvImport::class => false,
+			'RdnCsv:CsvExport'      => false,
+			'RdnCsv:CsvImport'      => false,
 		),
 	),
 );

--- a/tests/RdnCsv/Controller/Plugin/CsvExportTest.php
+++ b/tests/RdnCsv/Controller/Plugin/CsvExportTest.php
@@ -5,6 +5,7 @@ namespace RdnCsv\Controller\Plugin;
 use org\bovigo\vfs\vfsStream;
 use Zend\Mvc\Controller\PluginManager;
 use Zend\ServiceManager\Config;
+use Zend\ServiceManager\ServiceManager;
 
 class CsvExportTest extends \PHPUnit_Framework_TestCase
 {
@@ -68,7 +69,7 @@ CSV;
 	public function testPlugin()
 	{
 		$config = include __DIR__ .'/../../../../config/module.config.php';
-		$plugins = new PluginManager(new Config($config['controller_plugins']));
+		$plugins = new PluginManager(new ServiceManager(), $config['controller_plugins']);
 
 		$plugin = $plugins->get('CsvExport');
 		$this->assertInstanceOf('RdnCsv\Controller\Plugin\CsvExport', $plugin);

--- a/tests/RdnCsv/Controller/Plugin/CsvImportTest.php
+++ b/tests/RdnCsv/Controller/Plugin/CsvImportTest.php
@@ -5,6 +5,7 @@ namespace RdnCsv\Controller\Plugin;
 use org\bovigo\vfs\vfsStream;
 use Zend\Mvc\Controller\PluginManager;
 use Zend\ServiceManager\Config;
+use Zend\ServiceManager\ServiceManager;
 
 class CsvImportTest extends \PHPUnit_Framework_TestCase
 {
@@ -58,7 +59,7 @@ CSV
 	public function testPlugin()
 	{
 		$config = include __DIR__ .'/../../../../config/module.config.php';
-		$plugins = new PluginManager(new Config($config['controller_plugins']));
+		$plugins = new PluginManager(new ServiceManager(), $config['controller_plugins']);
 
 		$plugin = $plugins->get('CsvImport');
 		$this->assertInstanceOf('RdnCsv\Controller\Plugin\CsvImport', $plugin);


### PR DESCRIPTION
This does the following:

- Updates the configuration to work with either zend-servicemanager v2 or v3, and have the same behavior in each version.
- Updates the unit tests to work under both versions.